### PR TITLE
[PR] Allow a theme to declare partial support for Univerity Centers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.2.1 (October 9, 2014)
+
+* Check for theme support for `wsuwp_uc_person`, `wsuwp_uc_entity`, and `wsuwp_uc_project` before registering post types and taxonomies.
+    * If one of these is registered, we leave it in the hands of the theme to decide what is supported.
+    * If none of these are registered, we assume that intent is to support all.


### PR DESCRIPTION
If a theme uses `add_theme_support()` to declare intent to use a single portion, such as people, then we should not register the other portions of the plugin.
