### PR TITLE
[PR] Declare the class global before starting the class.

### DIFF
--- a/wsuwp-university-center.php
+++ b/wsuwp-university-center.php
@@ -1183,6 +1183,7 @@ class WSUWP_University_Center {
 		}
 	}
 }
+global $wsuwp_university_center;
 $wsuwp_university_center = new WSUWP_University_Center();
 
 /**


### PR DESCRIPTION
Otherwise things get crazy and we get errors when trying to load wp-cli.