### PR TITLE
[PR] Expand university center shortcodes for content syndication

### DIFF
--- a/includes/university-center-syndicate-shortcode-entity.php
+++ b/includes/university-center-syndicate-shortcode-entity.php
@@ -12,6 +12,17 @@ class University_Center_Syndicate_Shortcode_Entity extends WSU_Syndicate_Shortco
 	);
 
 	/**
+	 * @since 0.8.0
+	 *
+	 * @var array A set of default attributes for this shortcode only.
+	 */
+	public $local_extended_atts = array(
+		'person' => '',
+		'project' => '',
+		'publication' => '',
+	);
+
+	/**
 	 * @var string Shortcode name.
 	 */
 	public $shortcode_name = 'wsuwp_uc_entities';

--- a/includes/university-center-syndicate-shortcode-entity.php
+++ b/includes/university-center-syndicate-shortcode-entity.php
@@ -57,6 +57,17 @@ class University_Center_Syndicate_Shortcode_Entity extends WSU_Syndicate_Shortco
 		$request_url = esc_url( $site_url['host'] . $site_url['path'] . $this->default_path ) . $atts['query'];
 		$request_url = $this->build_taxonomy_filters( $atts, $request_url );
 
+		if ( ! empty( $atts['person'] ) ) {
+			$slug = sanitize_key( $atts['person'] );
+			$request_url = add_query_arg( array( 'filter[uc_person]' => $slug ), $request_url );
+		} elseif ( ! empty( $atts['project'] ) ) {
+			$slug = sanitize_key( $atts['project'] );
+			$request_url = add_query_arg( array( 'filter[uc_project]' => $slug ), $request_url );
+		} elseif ( ! empty( $atts['publication'] ) ) {
+			$slug = sanitize_key( $atts['publication'] );
+			$request_url = add_query_arg( array( 'filter[uc_publication]' => $slug ), $request_url );
+		}
+
 		if ( $atts['count'] ) {
 			$count = ( 100 < absint( $atts['count'] ) ) ? 100 : $atts['count'];
 			$request_url = add_query_arg( array( 'per_page' => absint( $count ) ), $request_url );

--- a/includes/university-center-syndicate-shortcode-entity.php
+++ b/includes/university-center-syndicate-shortcode-entity.php
@@ -115,7 +115,9 @@ class University_Center_Syndicate_Shortcode_Entity extends WSU_Syndicate_Shortco
 			ob_start();
 			?>
 			<div class="content-syndicate-entity-container">
-				<div class="uco-syndicate-entity-name"><?php echo esc_html( $entity->title->rendered ); ?></div>
+				<div class="uco-syndicate-entity-name">
+					<a href="<?php echo esc_url( $entity->link ); ?>"><?php echo esc_html( $entity->title->rendered ); ?></a>
+				</div>
 			</div>
 			<?php
 			$html = ob_get_contents();

--- a/includes/university-center-syndicate-shortcode-entity.php
+++ b/includes/university-center-syndicate-shortcode-entity.php
@@ -8,6 +8,7 @@ class University_Center_Syndicate_Shortcode_Entity extends WSU_Syndicate_Shortco
 	public $local_default_atts = array(
 		'output' => 'headlines',
 		'host'   => '',
+		'site'   => '',
 		'query'  => 'entities',
 	);
 
@@ -45,6 +46,10 @@ class University_Center_Syndicate_Shortcode_Entity extends WSU_Syndicate_Shortco
 	 */
 	public function display_shortcode( $atts ) {
 		$atts = $this->process_attributes( $atts );
+
+		if ( '' === $atts['host'] && '' === $atts['site'] ) {
+			$atts['site'] = get_home_url();
+		}
 
 		if ( ! $site_url = $this->get_request_url( $atts ) ) {
 			return '<!-- ' . $this->shortcode_name . ' ERROR - an empty host was supplied -->';

--- a/includes/university-center-syndicate-shortcode-person.php
+++ b/includes/university-center-syndicate-shortcode-person.php
@@ -57,6 +57,17 @@ class University_Center_Syndicate_Shortcode_Person extends WSU_Syndicate_Shortco
 		$request_url = esc_url( $site_url['host'] . $site_url['path'] . $this->default_path ) . $atts['query'];
 		$request_url = $this->build_taxonomy_filters( $atts, $request_url );
 
+		if ( ! empty( $atts['entity'] ) ) {
+			$slug = sanitize_key( $atts['entity'] );
+			$request_url = add_query_arg( array( 'filter[uc_entity]' => $slug ), $request_url );
+		} elseif ( ! empty( $atts['project'] ) ) {
+			$slug = sanitize_key( $atts['project'] );
+			$request_url = add_query_arg( array( 'filter[uc_project]' => $slug ), $request_url );
+		} elseif ( ! empty( $atts['publication'] ) ) {
+			$slug = sanitize_key( $atts['publication'] );
+			$request_url = add_query_arg( array( 'filter[uc_publication]' => $slug ), $request_url );
+		}
+
 		if ( $atts['count'] ) {
 			$count = ( 100 < absint( $atts['count'] ) ) ? 100 : $atts['count'];
 			$request_url = add_query_arg( array( 'per_page' => absint( $count ) ), $request_url );

--- a/includes/university-center-syndicate-shortcode-person.php
+++ b/includes/university-center-syndicate-shortcode-person.php
@@ -115,7 +115,9 @@ class University_Center_Syndicate_Shortcode_Person extends WSU_Syndicate_Shortco
 			ob_start();
 			?>
 			<div class="content-syndicate-person-container">
-				<div class="uco-syndicate-person-name"><?php echo esc_html( $person->title->rendered ); ?></div>
+				<div class="uco-syndicate-person-name">
+					<a href="<?php echo esc_url( $person->link ); ?>"><?php echo esc_html( $person->title->rendered ); ?></a>
+				</div>
 			</div>
 			<?php
 			$html = ob_get_contents();

--- a/includes/university-center-syndicate-shortcode-person.php
+++ b/includes/university-center-syndicate-shortcode-person.php
@@ -12,6 +12,18 @@ class University_Center_Syndicate_Shortcode_Person extends WSU_Syndicate_Shortco
 	);
 
 	/**
+	 * @since 0.8.0
+	 *
+	 * @var array A set of default attributes for this shortcode only.
+	 */
+	public $local_extended_atts = array(
+		'organization' => '',
+		'entity' => '',
+		'project' => '',
+		'publication' => '',
+	);
+
+	/**
 	 * @var string Shortcode name.
 	 */
 	public $shortcode_name = 'wsuwp_uc_people';

--- a/includes/university-center-syndicate-shortcode-person.php
+++ b/includes/university-center-syndicate-shortcode-person.php
@@ -8,6 +8,7 @@ class University_Center_Syndicate_Shortcode_Person extends WSU_Syndicate_Shortco
 	public $local_default_atts = array(
 		'output' => 'headlines',
 		'host'   => '',
+		'site'   => '',
 		'query'  => 'people',
 	);
 
@@ -45,6 +46,10 @@ class University_Center_Syndicate_Shortcode_Person extends WSU_Syndicate_Shortco
 	 */
 	public function display_shortcode( $atts ) {
 		$atts = $this->process_attributes( $atts );
+
+		if ( '' === $atts['host'] && '' === $atts['site'] ) {
+			$atts['site'] = get_home_url();
+		}
 
 		if ( ! $site_url = $this->get_request_url( $atts ) ) {
 			return '<!-- ' . $this->shortcode_name . ' ERROR - an empty host was supplied -->';

--- a/includes/university-center-syndicate-shortcode-person.php
+++ b/includes/university-center-syndicate-shortcode-person.php
@@ -17,7 +17,6 @@ class University_Center_Syndicate_Shortcode_Person extends WSU_Syndicate_Shortco
 	 * @var array A set of default attributes for this shortcode only.
 	 */
 	public $local_extended_atts = array(
-		'organization' => '',
 		'entity' => '',
 		'project' => '',
 		'publication' => '',

--- a/includes/university-center-syndicate-shortcode-project.php
+++ b/includes/university-center-syndicate-shortcode-project.php
@@ -8,6 +8,7 @@ class University_Center_Syndicate_Shortcode_Project extends WSU_Syndicate_Shortc
 	public $local_default_atts = array(
 		'output' => 'headlines',
 		'host'   => '',
+		'site'   => '',
 		'query'  => 'projects',
 	);
 
@@ -45,6 +46,10 @@ class University_Center_Syndicate_Shortcode_Project extends WSU_Syndicate_Shortc
 	 */
 	public function display_shortcode( $atts ) {
 		$atts = $this->process_attributes( $atts );
+
+		if ( '' === $atts['host'] && '' === $atts['site'] ) {
+			$atts['site'] = get_home_url();
+		}
 
 		if ( ! $site_url = $this->get_request_url( $atts ) ) {
 			return '<!-- ' . $this->shortcode_name . ' ERROR - an empty host was supplied -->';

--- a/includes/university-center-syndicate-shortcode-project.php
+++ b/includes/university-center-syndicate-shortcode-project.php
@@ -12,6 +12,17 @@ class University_Center_Syndicate_Shortcode_Project extends WSU_Syndicate_Shortc
 	);
 
 	/**
+	 * @since 0.8.0
+	 *
+	 * @var array A set of default attributes for this shortcode only.
+	 */
+	public $local_extended_atts = array(
+		'entity' => '',
+		'person' => '',
+		'publication' => '',
+	);
+
+	/**
 	 * @var string Shortcode name.
 	 */
 	public $shortcode_name = 'wsuwp_uc_projects';

--- a/includes/university-center-syndicate-shortcode-project.php
+++ b/includes/university-center-syndicate-shortcode-project.php
@@ -57,6 +57,17 @@ class University_Center_Syndicate_Shortcode_Project extends WSU_Syndicate_Shortc
 		$request_url = esc_url( $site_url['host'] . $site_url['path'] . $this->default_path ) . $atts['query'];
 		$request_url = $this->build_taxonomy_filters( $atts, $request_url );
 
+		if ( ! empty( $atts['entity'] ) ) {
+			$slug = sanitize_key( $atts['entity'] );
+			$request_url = add_query_arg( array( 'filter[uc_entity]' => $slug ), $request_url );
+		} elseif ( ! empty( $atts['person'] ) ) {
+			$slug = sanitize_key( $atts['person'] );
+			$request_url = add_query_arg( array( 'filter[uc_person]' => $slug ), $request_url );
+		} elseif ( ! empty( $atts['publication'] ) ) {
+			$slug = sanitize_key( $atts['publication'] );
+			$request_url = add_query_arg( array( 'filter[uc_publication]' => $slug ), $request_url );
+		}
+
 		if ( $atts['count'] ) {
 			$count = ( 100 < absint( $atts['count'] ) ) ? 100 : $atts['count'];
 			$request_url = add_query_arg( array( 'per_page' => absint( $count ) ), $request_url );

--- a/includes/university-center-syndicate-shortcode-project.php
+++ b/includes/university-center-syndicate-shortcode-project.php
@@ -115,7 +115,9 @@ class University_Center_Syndicate_Shortcode_Project extends WSU_Syndicate_Shortc
 			ob_start();
 			?>
 			<div class="content-syndicate-project-container">
-				<div class="uco-syndicate-project-name"><?php echo esc_html( $project->title->rendered ); ?></div>
+				<div class="uco-syndicate-project-name">
+					<a href="<?php echo esc_url( $project->link ); ?>"><?php echo esc_html( $project->title->rendered ); ?></a>
+				</div>
 			</div>
 			<?php
 			$html = ob_get_contents();

--- a/includes/university-center-syndicate-shortcode-publication.php
+++ b/includes/university-center-syndicate-shortcode-publication.php
@@ -8,6 +8,7 @@ class University_Center_Syndicate_Shortcode_Publication extends WSU_Syndicate_Sh
 	public $local_default_atts = array(
 		'output' => 'headlines',
 		'host'   => '',
+		'site'   => '',
 		'query'  => 'publications',
 	);
 
@@ -45,6 +46,10 @@ class University_Center_Syndicate_Shortcode_Publication extends WSU_Syndicate_Sh
 	 */
 	public function display_shortcode( $atts ) {
 		$atts = $this->process_attributes( $atts );
+
+		if ( '' === $atts['host'] && '' === $atts['site'] ) {
+			$atts['site'] = get_home_url();
+		}
 
 		if ( ! $site_url = $this->get_request_url( $atts ) ) {
 			return '<!-- ' . $this->shortcode_name . ' ERROR - an empty host was supplied -->';

--- a/includes/university-center-syndicate-shortcode-publication.php
+++ b/includes/university-center-syndicate-shortcode-publication.php
@@ -115,7 +115,9 @@ class University_Center_Syndicate_Shortcode_Publication extends WSU_Syndicate_Sh
 			ob_start();
 			?>
 			<div class="content-syndicate-publication-container">
-				<div class="uco-syndicate-publication-name"><?php echo esc_html( $publication->title->rendered ); ?></div>
+				<div class="uco-syndicate-publication-name">
+					<a href="<?php echo esc_url( $publication->link ); ?>"><?php echo esc_html( $publication->title->rendered ); ?></a>
+				</div>
 			</div>
 			<?php
 			$html = ob_get_contents();

--- a/includes/university-center-syndicate-shortcode-publication.php
+++ b/includes/university-center-syndicate-shortcode-publication.php
@@ -12,6 +12,17 @@ class University_Center_Syndicate_Shortcode_Publication extends WSU_Syndicate_Sh
 	);
 
 	/**
+	 * @since 0.8.0
+	 *
+	 * @var array A set of default attributes for this shortcode only.
+	 */
+	public $local_extended_atts = array(
+		'entity' => '',
+		'person' => '',
+		'project' => '',
+	);
+
+	/**
 	 * @var string Shortcode name.
 	 */
 	public $shortcode_name = 'wsuwp_uc_publications';

--- a/includes/university-center-syndicate-shortcode-publication.php
+++ b/includes/university-center-syndicate-shortcode-publication.php
@@ -57,6 +57,17 @@ class University_Center_Syndicate_Shortcode_Publication extends WSU_Syndicate_Sh
 		$request_url = esc_url( $site_url['host'] . $site_url['path'] . $this->default_path ) . $atts['query'];
 		$request_url = $this->build_taxonomy_filters( $atts, $request_url );
 
+		if ( ! empty( $atts['entity'] ) ) {
+			$slug = sanitize_key( $atts['entity'] );
+			$request_url = add_query_arg( array( 'filter[uc_entity]' => $slug ), $request_url );
+		} elseif ( ! empty( $atts['person'] ) ) {
+			$slug = sanitize_key( $atts['person'] );
+			$request_url = add_query_arg( array( 'filter[uc_person]' => $slug ), $request_url );
+		} elseif ( ! empty( $atts['project'] ) ) {
+			$slug = sanitize_key( $atts['project'] );
+			$request_url = add_query_arg( array( 'filter[uc_project]' => $slug ), $request_url );
+		}
+
 		if ( $atts['count'] ) {
 			$count = ( 100 < absint( $atts['count'] ) ) ? 100 : $atts['count'];
 			$request_url = add_query_arg( array( 'per_page' => absint( $count ) ), $request_url );

--- a/wsuwp-university-center.php
+++ b/wsuwp-university-center.php
@@ -1176,13 +1176,13 @@ class WSUWP_University_Center {
 		if ( isset( $query->query['uc_organization'] ) && ! empty( $query->query['uc_organization'] ) ) {
 			$slug = sanitize_title( $query->query['uc_organization'] );
 			$type = $this->entity_content_type;
-		} else if ( isset( $query->query['uc_person'] ) && ! empty( $query->query['uc_person'] ) ) {
+		} elseif ( isset( $query->query['uc_person'] ) && ! empty( $query->query['uc_person'] ) ) {
 			$slug = sanitize_title( $query->query['uc_person'] );
 			$type = $this->people_content_type;
-		} else if ( isset( $query->query['uc_publication'] ) && ! empty( $query->query['uc_publication'] ) ) {
+		} elseif ( isset( $query->query['uc_publication'] ) && ! empty( $query->query['uc_publication'] ) ) {
 			$slug = sanitize_title( $query->query['uc_publication'] );
 			$type = $this->publication_content_type;
-		} else if ( isset( $query->query['uc_project'] ) && ! empty( $query->query['uc_project'] ) ) {
+		} elseif ( isset( $query->query['uc_project'] ) && ! empty( $query->query['uc_project'] ) ) {
 			$slug = sanitize_title( $query->query['uc_project'] );
 			$type = $this->project_content_type;
 		} else {

--- a/wsuwp-university-center.php
+++ b/wsuwp-university-center.php
@@ -1146,14 +1146,14 @@ class WSUWP_University_Center {
 
 	/**
 	 * Adds custom query vars to allow the filtering of REST API results by
-	 * organization, person, publication, or project.
+	 * entity, person, publication, or project.
 	 *
 	 * @since 0.8.0
 	 */
 	public function add_query_vars() {
 		global $wp;
 
-		$wp->add_query_var( 'uc_organization' );
+		$wp->add_query_var( 'uc_entity' );
 		$wp->add_query_var( 'uc_person' );
 		$wp->add_query_var( 'uc_publication' );
 		$wp->add_query_var( 'uc_project' );
@@ -1173,8 +1173,8 @@ class WSUWP_University_Center {
 		// If we don't remove this filter, we'll start an infinite loop.
 		remove_filter( 'pre_get_posts', array( $this, 'filter_rest_query' ) );
 
-		if ( isset( $query->query['uc_organization'] ) && ! empty( $query->query['uc_organization'] ) ) {
-			$slug = sanitize_title( $query->query['uc_organization'] );
+		if ( isset( $query->query['uc_entity'] ) && ! empty( $query->query['uc_entity'] ) ) {
+			$slug = sanitize_title( $query->query['uc_entity'] );
 			$type = $this->entity_content_type;
 		} elseif ( isset( $query->query['uc_person'] ) && ! empty( $query->query['uc_person'] ) ) {
 			$slug = sanitize_title( $query->query['uc_person'] );

--- a/wsuwp-university-center.php
+++ b/wsuwp-university-center.php
@@ -90,6 +90,8 @@ class WSUWP_University_Center {
 
 		add_filter( 'the_content', array( $this, 'add_object_content' ), 999, 1 );
 
+		add_action( 'init', array( $this, 'add_query_vars' ), 10 );
+		add_action( 'pre_get_posts', array( $this, 'filter_rest_query' ), 10 );
 		add_action( 'pre_get_posts', array( $this, 'filter_query' ), 10 );
 	}
 
@@ -1140,6 +1142,71 @@ class WSUWP_University_Center {
 		}
 
 		return $content . $added_html;
+	}
+
+	/**
+	 * Adds custom query vars to allow the filtering of REST API results by
+	 * organization, person, publication, or project.
+	 *
+	 * @since 0.8.0
+	 */
+	public function add_query_vars() {
+		global $wp;
+
+		$wp->add_query_var( 'uc_organization' );
+		$wp->add_query_var( 'uc_person' );
+		$wp->add_query_var( 'uc_publication' );
+		$wp->add_query_var( 'uc_project' );
+	}
+
+	/**
+	 * Restricts a REST API request result to a set of IDs when a
+	 * corresponding query var is provided.
+	 *
+	 * @param WP_Query $query
+	 */
+	public function filter_rest_query( $query ) {
+		if ( ! defined( 'REST_REQUEST' ) || true !== REST_REQUEST ) {
+			return;
+		}
+
+		// If we don't remove this filter, we'll start an infinite loop.
+		remove_filter( 'pre_get_posts', array( $this, 'filter_rest_query' ) );
+
+		if ( isset( $query->query['uc_organization'] ) && ! empty( $query->query['uc_organization'] ) ) {
+			$slug = sanitize_title( $query->query['uc_organization'] );
+			$type = $this->entity_content_type;
+		} else if ( isset( $query->query['uc_person'] ) && ! empty( $query->query['uc_person'] ) ) {
+			$slug = sanitize_title( $query->query['uc_person'] );
+			$type = $this->people_content_type;
+		} else if ( isset( $query->query['uc_publication'] ) && ! empty( $query->query['uc_publication'] ) ) {
+			$slug = sanitize_title( $query->query['uc_publication'] );
+			$type = $this->publication_content_type;
+		} else if ( isset( $query->query['uc_project'] ) && ! empty( $query->query['uc_project'] ) ) {
+			$slug = sanitize_title( $query->query['uc_project'] );
+			$type = $this->project_content_type;
+		} else {
+			return;
+		}
+
+		$posts = get_posts( array( 'post_type' => $type, 'name' => $slug ) );
+
+		if ( 0 === count( $posts ) ) {
+			$query->set( 'post__in', array( 0 ) );
+			return;
+		}
+
+		$objects = wsuwp_uc_get_object_objects( $posts[0]->ID, $query->query['post_type'] );
+
+		if ( empty( $objects ) ) {
+			$query->set( 'post__in', array( 0 ) );
+			return;
+		}
+
+		$ids = array_values( wp_list_pluck( $objects, 'id' ) );
+
+		$query->set( 'post__in', $ids );
+		$query->set( 'per_page', 100 );
 	}
 
 	/**


### PR DESCRIPTION
Provides the ability to filter a content syndicate shortcode's response to a subset of associated objects:

`[wsuwp_uc_people project="cool-project"]` will pull in all people associated with the `cool-project` project.

This PR also adjusts the handling of the `host` or `site` attribute so that the current site's home URL is used as a fallback if none is specified.